### PR TITLE
Fix register button bug

### DIFF
--- a/src/sections/hero/HeroContent.vue
+++ b/src/sections/hero/HeroContent.vue
@@ -102,6 +102,7 @@ export default {
   width: 265px;
   height: 0;
   transition: background-color 0.6s ease-out, color 0.6s ease-out;
+  line-height: 0px;
 }
 
 .caution-button {


### PR DESCRIPTION
Sometimes, without this fix, it is not vertically aligned on some mobile devices. By setting the line-height to 0px, it is always vertically aligned and the register text is always vertically centered on the register button.